### PR TITLE
Make syslog config check more permissive

### DIFF
--- a/jobs/syslog-configuration-test/templates/post-deploy.sh
+++ b/jobs/syslog-configuration-test/templates/post-deploy.sh
@@ -27,8 +27,12 @@ load_ryslogd_config_check() {
   set -e
 }
 
+# Store the regex to match if the imfile module is loaded in a variable, for use in bash
+# test brackets [[ ]]
+imfile_match="loading module *.*imfile.so"
+
 ensure_rsyslog_imfile_module_loaded() {
-  [[ $RSYSLOG_CONFIG_CHECK = *"loading module '/usr/lib/rsyslog/imfile.so'"* ]] ||
+  [[ $RSYSLOG_CONFIG_CHECK =~ $imfile_match ]] ||
   fail "rsyslog imfile not loaded, can't watch log files"
 }
 


### PR DESCRIPTION
## Why is do we need this?
This is to prevent failures in the event that a change in stemcell causes filesystem changes. The move to new a stemcell seems to have introduced a filesystem change for the deafult installation location for the rsyslogd modules.

Originally we were checking that the rsyslog configuration contained this substring 

`loading module '/usr/lib/rsyslog/imfile.so'`

In the new stemcell the rsyslogd conig shows that the imfile.so location is

`0432.047353666:main thread    : modules.c: loading module '/usr/lib/x86_64-linux-gnu/rsyslog/imfile.so'`

This commit changes the check, so that we are only looking for `imfile.so'` in the rsyslogd config. This should prevent failures if the location changes again in a future stemcell change. 